### PR TITLE
Consistency in grays across project descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
         </div>
         <div class="pvm">
           <a class="f2 mega-ns link b" href="http://nkd.cc">nkd</a>
-          <p class="man lh-copy serif-calisto f4 dark-gray fw4">
+          <p class="man lh-copy serif-calisto f4 md-gray fw4">
             Scaffolding for a simple jekyll project. 
           </p>
         </div>


### PR DESCRIPTION
The rest of the project descriptions are classed `md-gray`, this one was `dark-gray`. If intentional, ignore this.
